### PR TITLE
타이틀씬 버튼 호버링 시 중복 하이라이트 버그 수정

### DIFF
--- a/Assets/Scenes/Jungi/TitleScene.unity
+++ b/Assets/Scenes/Jungi/TitleScene.unity
@@ -640,6 +640,7 @@ GameObject:
   - component: {fileID: 688636837}
   - component: {fileID: 688636836}
   - component: {fileID: 688636835}
+  - component: {fileID: 688636838}
   m_Layer: 5
   m_Name: OptionButton
   m_TagString: Untagged
@@ -749,6 +750,51 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 688636833}
   m_CullTransparentMesh: 1
+--- !u!114 &688636838
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 688636833}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates:
+  - eventID: 0
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 422294669}
+          m_TargetAssemblyTypeName: TitleManager, Assembly-CSharp
+          m_MethodName: OnPointerEnter
+          m_Mode: 0
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+  - eventID: 1
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 422294669}
+          m_TargetAssemblyTypeName: TitleManager, Assembly-CSharp
+          m_MethodName: OnPointerExit
+          m_Mode: 0
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
 --- !u!1 &705507993
 GameObject:
   m_ObjectHideFlags: 0
@@ -1230,6 +1276,7 @@ GameObject:
   - component: {fileID: 1710539299}
   - component: {fileID: 1710539298}
   - component: {fileID: 1710539297}
+  - component: {fileID: 1710539300}
   m_Layer: 5
   m_Name: StartButton
   m_TagString: Untagged
@@ -1351,6 +1398,51 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1710539295}
   m_CullTransparentMesh: 1
+--- !u!114 &1710539300
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1710539295}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates:
+  - eventID: 0
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 422294669}
+          m_TargetAssemblyTypeName: TitleManager, Assembly-CSharp
+          m_MethodName: OnPointerEnter
+          m_Mode: 0
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+  - eventID: 1
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 422294669}
+          m_TargetAssemblyTypeName: TitleManager, Assembly-CSharp
+          m_MethodName: OnPointerExit
+          m_Mode: 0
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
 --- !u!1 &1750252583
 GameObject:
   m_ObjectHideFlags: 0
@@ -1363,6 +1455,7 @@ GameObject:
   - component: {fileID: 1750252587}
   - component: {fileID: 1750252586}
   - component: {fileID: 1750252585}
+  - component: {fileID: 1750252588}
   m_Layer: 5
   m_Name: ExitButton
   m_TagString: Untagged
@@ -1472,6 +1565,51 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1750252583}
   m_CullTransparentMesh: 1
+--- !u!114 &1750252588
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1750252583}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates:
+  - eventID: 0
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 422294669}
+          m_TargetAssemblyTypeName: TitleManager, Assembly-CSharp
+          m_MethodName: OnPointerEnter
+          m_Mode: 0
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
+  - eventID: 1
+    callback:
+      m_PersistentCalls:
+        m_Calls:
+        - m_Target: {fileID: 422294669}
+          m_TargetAssemblyTypeName: TitleManager, Assembly-CSharp
+          m_MethodName: OnPointerExit
+          m_Mode: 0
+          m_Arguments:
+            m_ObjectArgument: {fileID: 0}
+            m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+            m_IntArgument: 0
+            m_FloatArgument: 0
+            m_StringArgument: 
+            m_BoolArgument: 0
+          m_CallState: 2
 --- !u!1 &1841345893
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Title/TitleManager.cs
+++ b/Assets/Scripts/Title/TitleManager.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.EventSystems;
 using UnityEngine.SceneManagement;
 
 public class TitleManager : MonoBehaviour
@@ -8,22 +9,24 @@ public class TitleManager : MonoBehaviour
     public List<Button> menuButtons;
     private int currentIndex = 0;
 
+    /* ---------- Unity lifecycle ---------- */
     private void Start()
     {
-        HighlightButton(currentIndex);
+        SelectButton(currentIndex);   // 처음 버튼 선택
     }
 
     private void Update()
     {
+        // ↓↓ 키보드 네비게이션 ↓↓
         if (Input.GetKeyDown(KeyCode.DownArrow))
         {
             currentIndex = (currentIndex + 1) % menuButtons.Count;
-            HighlightButton(currentIndex);
+            SelectButton(currentIndex);
         }
         else if (Input.GetKeyDown(KeyCode.UpArrow))
         {
             currentIndex = (currentIndex - 1 + menuButtons.Count) % menuButtons.Count;
-            HighlightButton(currentIndex);
+            SelectButton(currentIndex);
         }
         else if (Input.GetKeyDown(KeyCode.Return))
         {
@@ -31,29 +34,54 @@ public class TitleManager : MonoBehaviour
         }
     }
 
-    private void HighlightButton(int index)
+    /* ---------- 공용 선택 로직 ---------- */
+    private void SelectButton(int index)
+    {
+        // Unity 내장 Selectable 시스템 활용 → 마우스·키보드 색상 통일
+        menuButtons[index].Select();
+        UpdateColors(index);
+    }
+
+    private void UpdateColors(int selected)
     {
         for (int i = 0; i < menuButtons.Count; i++)
         {
-            ColorBlock colors = menuButtons[i].colors;
-            colors.normalColor = (i == index) ? Color.green : Color.white;
-            menuButtons[i].colors = colors;
+            Color tint = (i == selected) ? Color.green : Color.white;
+
+            ColorBlock cb         = menuButtons[i].colors;
+            cb.normalColor        = tint;   // 기본
+            cb.highlightedColor   = tint;   // 마우스 호버
+            cb.selectedColor      = tint;   // 키보드/게임패드 선택
+            cb.pressedColor       = new Color(tint.r * 0.7f, tint.g * 0.7f, tint.b * 0.7f);
+
+            menuButtons[i].colors = cb;
         }
     }
 
-    // 버튼 클릭 시 실행
-    public void StartGame()
+    /* ---------- EventTrigger에서 호출 ---------- */
+    // **Point Enter** 에 연결
+    public void OnPointerEnter(BaseEventData data)
     {
-        StartCoroutine(FadeManager.Instance.FadeAndLoadScene("GameScene")); // GameScene으로 이동
+        var ped = data as PointerEventData;
+        if (ped == null) return;
+
+        // Text, Image 같은 자식 오브젝트에서도 Button을 찾도록
+        var btn = ped.pointerEnter?.GetComponentInParent<Button>();
+        if (btn == null) return;
+
+        currentIndex = menuButtons.IndexOf(btn);
+        SelectButton(currentIndex);   // 색상 재계산
     }
 
-    public void Option()
+
+    // **Point Exit** (선택적) – 나가더라도 마지막으로 선택된 버튼 유지
+    public void OnPointerExit(BaseEventData data)
     {
-        Debug.Log("Option 버튼 눌림");
+        UpdateColors(currentIndex);
     }
 
-    public void ExitGame()
-    {
-        Application.Quit();
-    }
+    /* ---------- 버튼 클릭 콜백 ---------- */
+    public void StartGame()  => StartCoroutine(FadeManager.Instance.FadeAndLoadScene("GameScene"));
+    public void Option()     => Debug.Log("Option 버튼 눌림");
+    public void ExitGame()   => Application.Quit();
 }

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -8,6 +8,12 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/Player_Prototype.unity
     guid: 99c9720ab356a0642a771bea13969a05
+  - enabled: 1
+    path: Assets/Scenes/Jungi/TitleScene.unity
+    guid: 9fc0d4010bbf28b4594072e72b8655ab
+  - enabled: 1
+    path: Assets/Scenes/Jungi/GameScene.unity
+    guid: 2eaf101f21f464293b85817e0a426be9
   m_configObjects:
     com.unity.input.settings.actions: {fileID: -944628639613478452, guid: 052faaac586de48259a63d0c4782560b, type: 3}
   m_UseUCBPForAssetBundles: 0


### PR DESCRIPTION
# fix: TitleScene 버튼 호버링 시 중복 하이라이트 오류 수정 (#15)

## 관련 Issue(s)
closes #15 (TitleScene 버튼 호버링 문제)

## PR 설명
키보드 선택과 마우스 호버가 동시에 적용돼 두 개의 버튼이 동시에 초록색으로 표시되던 문제를 해결했습니다.
UpdateColors() 로직을 재작성해 선택된 버튼 하나만 초록색으로 표시되도록 통일했으며, OnPointerEnter()에서 자식 오브젝트(텍스트, 이미지)까지 감지해 정확히 상위 Button을 찾도록 변경했습니다.

### Changes Included

TitleManager.cs
--
UpdateColors() 색상 로직 단순화
OnPointerEnter()에서 GetComponentInParent<Button>() 사용
pressedColor 추가로 클릭 피드백 강화
      
### Screenshots 
![output](https://github.com/user-attachments/assets/178b6f9c-6205-4d24-8dac-74769019a2eb)


### Notes for Reviewer

---
